### PR TITLE
Fix exponents

### DIFF
--- a/src/main/scala/com/fdilke/bewl/apps/BellNumbers.scala
+++ b/src/main/scala/com/fdilke/bewl/apps/BellNumbers.scala
@@ -9,6 +9,7 @@ object BellNumbers extends App {
   def bell(n: Int): Int = {
     val set: DOT[Int] = dot(0 until n :_*)
     implicit val set2 = set.squared
+    implicit val _ = set2.power
 
     val eqRelns = set2.power.whereAll(set) {
       (ssp, s) =>

--- a/src/main/scala/com/fdilke/bewl/apps/GraphComponents.scala
+++ b/src/main/scala/com/fdilke/bewl/apps/GraphComponents.scala
@@ -31,10 +31,11 @@ object GraphComponents extends App {
   val numComponents = components.globals.size
   println(s"$numComponents components")
 
+  import vertices.power.{ evaluate => $ }
   for {c <- elementsOf(components)} {
     print("component: { ")
     for {v <- elementsOf(vertices)}
-      if (c(v))
+      if ($(c, v))
         print(s"$v ")
     println("}")
   }

--- a/src/main/scala/com/fdilke/bewl/apps/YangBaxter.scala
+++ b/src/main/scala/com/fdilke/bewl/apps/YangBaxter.scala
@@ -11,7 +11,9 @@ object YangBaxter extends App {
     (BxB > BxB)(omega) { f =>
       val xx = (BxB > ((BxB.π1 o BxBxB.π0) x BxBxB.π1) )(f)
 
+/*      
       val hh: (((Int x Int) x Int) → (Int x Int)) = (BxB > BxBxB.π0)(f)
+*/      
 //      val _f_1 = (BxB > BxBxB.π0)(f) x BxBxB.π1
 
 //      val _1_f = (

--- a/src/main/scala/com/fdilke/bewl/fsets/FiniteSets.scala
+++ b/src/main/scala/com/fdilke/bewl/fsets/FiniteSets.scala
@@ -12,6 +12,8 @@ object FiniteSets extends Topos[Any] with Wrappings[
   override type >[S, T] = FiniteSetsArrow[S, T]
   override type UNIT = Unit
   override type TRUTH = Boolean
+  override type →[T <: ~, U <: ~] = (T => U) with ~
+  
   override lazy val I = makeDot(Traversable(()))
   override lazy val omega = makeDot(Traversable(true, false))
   override lazy val truth = I(omega) { _ => true }
@@ -54,6 +56,10 @@ object FiniteSets extends Topos[Any] with Wrappings[
         override def apply(s: S): T =
           function(s)
       }
+      val hh: DOT[S → T] with ExponentialDot[S, T, S → T] = ???
+      val kk: EXPONENTIAL[S, T] = hh
+      ???
+      
       new FiniteSetsDot[S → T](
         allMaps(self.elements, that.elements) map FunctionElement
       ) with ExponentialDot[S, T, S → T] { exponentialDot =>
@@ -64,7 +70,16 @@ object FiniteSets extends Topos[Any] with Wrappings[
           biArrow.product.left(exponentialDot) {
             r => FunctionElement {
               s => biArrow(r, s)
-            }}}}
+            }
+        }
+            
+        override def evaluate(
+            function: S → T, 
+            arg: S
+        ): T =
+          function(arg)
+      }
+    }
 
     override def apply[T](target: DOT[T])(f: S => T) =
       new FiniteSetsArrow(this, target, f)
@@ -211,8 +226,10 @@ object FiniteSetsUtilities {
 
   def asElement[X, Y](
     arrow: X > Y
-  ): X → Y =
+  ): X → Y = {
+    val xx: UNIT > (X → Y) = arrow.name
     arrow.name(())
+  }
 
   def makeNullaryOperator[X](
     carrier: DOT[X],

--- a/src/main/scala/com/fdilke/bewl/fsets/FiniteSets.scala
+++ b/src/main/scala/com/fdilke/bewl/fsets/FiniteSets.scala
@@ -56,9 +56,6 @@ object FiniteSets extends Topos[Any] with Wrappings[
         override def apply(s: S): T =
           function(s)
       }
-      val hh: DOT[S → T] with ExponentialDot[S, T, S → T] = ???
-      val kk: EXPONENTIAL[S, T] = hh
-      ???
       
       new FiniteSetsDot[S → T](
         allMaps(self.elements, that.elements) map FunctionElement
@@ -160,7 +157,11 @@ object FiniteSets extends Topos[Any] with Wrappings[
     source(target)(f)
 
   override def makeArrow[S, T](prearrow: FiniteSetsPreArrow[S, T]) =
-    makeDot(prearrow.source)(makeDot(prearrow.target))(prearrow.function)
+    makeDot(prearrow.source)(
+      makeDot(prearrow.target)
+    )(
+      prearrow.function
+    )
 
   override def makeDot[T](predot: Traversable[T]) =
     memoizedDotWrapper(predot)

--- a/src/main/scala/com/fdilke/bewl/topos/BaseTopos.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/BaseTopos.scala
@@ -14,7 +14,7 @@ trait BaseTopos {
   type DOT[S <: ~] <: Dot[S]
   type >[S <: ~, T <: ~] <: Arrow[S, T]
 
-  type →[T <: ~, U <: ~] = ~
+  type →[T <: ~, U <: ~] <: ~
   type x[T <: ~, U <: ~] = (T ⊕ U) with ~
 
   type UNIT <: ~

--- a/src/main/scala/com/fdilke/bewl/topos/algebra/AlgebraicConstructions.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/algebra/AlgebraicConstructions.scala
@@ -17,7 +17,7 @@ trait AlgebraicConstructions {
   class EndomorphismMonoid[T <: ~](
     dot: DOT[T]
   ) {
-    private val endos = dot > dot
+    private implicit val endos = dot > dot
 
     val monoid =
       new Monoid[T → T](endos, dot.identity.name,

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfAutomorphisms.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfAutomorphisms.scala
@@ -41,6 +41,7 @@ trait ConstructToposOfAutomorphisms extends
         override type DOT[X <: ~] = Automorphism[X]
         override type >[S <: ~, T <: ~] = AutomorphismArrow[S, T]
         override type TRUTH = Ɛ.TRUTH
+        override type →[T <: ~, U <: ~] = Ɛ.→[T, U]
         
         override val I = trivialAutomorphism(Ɛ.I)
         override val omega = trivialAutomorphism(Ɛ.omega)
@@ -84,7 +85,7 @@ trait ConstructToposOfAutomorphisms extends
           }
           override def `>Uncached`[Y <: ~](that: DOT[Y]) = {
             val exponentialCarrier = carrier > that.carrier
-            new Automorphism(
+            new Automorphism[X → Y](
               exponentialCarrier.transpose(exponentialCarrier) {
                 (e, x) => that.arrow(
                   exponentialCarrier.evaluate(e, inverse(x))

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfAutomorphisms.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfAutomorphisms.scala
@@ -41,7 +41,7 @@ trait ConstructToposOfAutomorphisms extends
         override type DOT[X <: ~] = Automorphism[X]
         override type >[S <: ~, T <: ~] = AutomorphismArrow[S, T]
         override type TRUTH = Ɛ.TRUTH
-
+        
         override val I = trivialAutomorphism(Ɛ.I)
         override val omega = trivialAutomorphism(Ɛ.omega)
         override val truth = AutomorphismArrow(I, omega, Ɛ.truth)
@@ -86,14 +86,28 @@ trait ConstructToposOfAutomorphisms extends
             val exponentialCarrier = carrier > that.carrier
             new Automorphism(
               exponentialCarrier.transpose(exponentialCarrier) {
-                (e, x) => that.arrow(e(inverse(x)))
+                (e, x) => that.arrow(
+                  exponentialCarrier.evaluate(e, inverse(x))
+                )
               },
               exponentialCarrier.transpose(exponentialCarrier) {
-                (e, x) => that.inverse(e(arrow(x)))
+                (e, x) => that.inverse(
+                   exponentialCarrier.evaluate(e, arrow(x))
+                )
               }
             ) with ExponentialDot[X, Y, X → Y] { exponentialAutomorphism =>
               override val source = automorphism
               override val target = that
+              
+              override def evaluate(
+                function: X → Y, 
+                arg: X
+              ): Y = 
+                exponentialCarrier.evaluate(
+                  function, 
+                  arg
+                )
+              
               override def transpose[R <: ~](biArrow: BiArrow[R, X, Y]): R > (X → Y) =
                 AutomorphismArrow(
                   biArrow.product.left,

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfGroupActions.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfGroupActions.scala
@@ -28,6 +28,7 @@ trait ConstructToposOfGroupActions extends
         override type >[X <: ~, Y <: ~] = ActionArrow[X, Y]
         override type UNIT = Ɛ.UNIT
         override type TRUTH = Ɛ.TRUTH
+        override type →[T <: ~, U <: ~] = Ɛ.→[T, U]
 
         override val I: DOT[UNIT] =
           ActionDot(Ɛ.I) { (i, g) => i }

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfGroupActions.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfGroupActions.scala
@@ -93,7 +93,8 @@ trait ConstructToposOfGroupActions extends
               group.action(exponentialDot) {
                 case (f, g) => exponentialDot.transpose(exp_x_G) {
                   case (f ⊕ g, a) => that.action.actionMultiply(
-                    f(
+                    exponentialDot.evaluate(
+                      f,
                       dot.action.actionMultiply(
                         a,
                         group.inverse(g)
@@ -120,6 +121,15 @@ trait ConstructToposOfGroupActions extends
                   ) {
                     biArrow(_, _)
                   }
+                )
+                
+               override def evaluate(
+                function: S → T, 
+                arg: S
+              ): T = 
+                exponentialDot.evaluate(
+                  function, 
+                  arg
                 )
             }
           }

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMaskables.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMaskables.scala
@@ -106,6 +106,7 @@ trait ConstructToposOfMaskables extends
 
     override type DOT[A <: ~] = MaskableDotFacade[A]
     override type >[A <: ~, B <: ~] = MaskableArrowFacade[A, B]
+    override type →[T <: ~, U <: ~] = Ɛ.→[T, U]
     
     override type UNIT = Ɛ.UNIT
     override type TRUTH = Ɛ.TRUTH
@@ -238,7 +239,13 @@ trait ConstructToposOfMaskables extends
            expEquiv
          ) with ExponentialDot[Z, A, Z → A] {
            override val source = pre 
-           override val target = dot 
+           override val target = dot
+           override def evaluate(
+             function: Z → A, 
+             arg: Z
+           ) =
+             ???
+             
            override def transpose[R <: ~](
              biArrow: BiArrow[R, Z, A]
            ): MaskableArrowFacade[R, Z → A] =

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActions.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActions.scala
@@ -69,6 +69,7 @@ trait ConstructToposOfMonoidActions extends
           override type DOT[AA <: ~~] = ActionDotFacade[AA]
           override type >[AA <: ~~, BB <: ~~] = ActionArrowFacade[AA, BB]
           override type UNIT = Ɛ.VanillaWrapper[Ɛ.UNIT]
+          override type →[T <: ~, U <: ~] = ~
 
           type IDEAL = Ɛ.→[M, Ɛ.TRUTH]
 

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActions.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActions.scala
@@ -80,10 +80,11 @@ trait ConstructToposOfMonoidActions extends
 
           private object Ideals {
             private val possibleIdeals = carrier.power
+            import possibleIdeals.{ evaluate => $ }
 
             private val ideals =
               possibleIdeals.whereAll(carrier, carrier) {
-                (f, m, n) => Ɛ.OmegaEnrichments(f(m)) → f(multiply(m, n))
+                (f, m, n) => Ɛ.OmegaEnrichments($(f, m)) → $(f, multiply(m, n))
               }
 
             def restrict[
@@ -97,7 +98,7 @@ trait ConstructToposOfMonoidActions extends
 
             private val idealMultiply =
               restrict(ideals x carrier) {
-                case (i ⊕ s, t) => ideals.inclusion(i)(multiply(s, t))
+                case (i ⊕ s, t) => $(ideals.inclusion(i), multiply(s, t))
               }
 
             val omega = ActionDot[IDEAL](ideals)(
@@ -264,6 +265,7 @@ trait ConstructToposOfMonoidActions extends
             ): EXPONENTIAL[ZZ, AA] = {
               val mXz = pre.pairs
               val possibleMorphisms = mXz > action.actionCarrier
+              import possibleMorphisms.{ evaluate => $ }
 
               type P = Ɛ.→[Ɛ.x[M, Z], A]
 
@@ -275,14 +277,14 @@ trait ConstructToposOfMonoidActions extends
                 ) {
                   case (f, n, m, z) =>
                     action.actionCarrier.=?=(
-                      f(
+                      $(f, 
                         mXz.pair(
                           multiply(m, n),
                           pre.action.actionMultiply(z, n)
                         )
                       ),
                       action.actionMultiply(
-                        f(
+                        $(f, 
                           mXz.pair(m, z)
                         ),
                         n
@@ -296,7 +298,7 @@ trait ConstructToposOfMonoidActions extends
                     morphisms x carrier
                   ) {
                     case (f ⊕ m, n ⊕ z) =>
-                      morphisms.inclusion(f)(
+                      $(morphisms.inclusion(f),
                         mXz.pair(multiply(m, n), z)
                       )
                   }
@@ -311,7 +313,7 @@ trait ConstructToposOfMonoidActions extends
                     (zz: ZZ) => {
                       val z = pre.↔ \ zz
                       val unitM: M = unit(pre.action.actionCarrier.toI(z))
-                      val a: A = p(mXz.pair(unitM, z))
+                      val a: A = $(p, mXz.pair(unitM, z))
                       dot.↔ / a
                     }
                   ),
@@ -322,10 +324,16 @@ trait ConstructToposOfMonoidActions extends
                   ExponentialWrapper[Z, ZZ, A, AA]
                 ] {
                   exponentialDot =>
-                  val source: DOT[ZZ] = pre
-                  val target: DOT[AA] = dot
+                  override val source: DOT[ZZ] = pre
+                  override val target: DOT[AA] = dot
 
-                  def transpose[RR <: ~~](
+                  override def evaluate(
+                      function: ExponentialWrapper[Z, ZZ, A, AA], 
+                      arg: ZZ
+                  ): AA =
+                    function(arg)
+                  
+                  override def transpose[RR <: ~~](
                     biArrow: BiArrow[RR, ZZ, AA]
                   ): RR > ExponentialWrapper[Z, ZZ, A, AA] =
                     biArrow.product.left.calcTranspose[Z, ZZ, A, AA](

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActionsAlt.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActionsAlt.scala
@@ -34,12 +34,13 @@ trait ConstructToposOfMonoidActionsAlt extends
 
           private object Ideals {
             private val possibleIdeals = carrier.power
+            import possibleIdeals.{ evaluate => $ }
 
             private val ideals =
               possibleIdeals.whereAll(carrier, carrier) {
                 (f, m, n) => 
-                  Ɛ.OmegaEnrichments(f(m)) → 
-                    f(monoid.multiply(m, n))
+                  Ɛ.OmegaEnrichments($(f, m)) → 
+                    $(f, monoid.multiply(m, n))
               }
 
             def restrict[
@@ -56,7 +57,7 @@ trait ConstructToposOfMonoidActionsAlt extends
             private val idealMultiply =
               restrict(ideals x carrier) {
                 case (i ⊕ s, t) => 
-                  ideals.inclusion(i)(
+                  $(ideals.inclusion(i),
                       monoid.multiply(s, t)
                   )
               }

--- a/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActionsAlt.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/constructions/ConstructToposOfMonoidActionsAlt.scala
@@ -23,6 +23,7 @@ trait ConstructToposOfMonoidActionsAlt extends
           override type DOT[A <: ~] = ActionDotFacade[A]
           override type >[A <: ~, B <: ~] = ActionArrowFacade[A, B]
           override type UNIT = Ɛ.UNIT
+          override type →[T <: ~, U <: ~] = Ɛ.→[T, U]
           
           type IDEAL = M → Ɛ.TRUTH
           override type TRUTH = IDEAL

--- a/src/main/scala/com/fdilke/bewl/topos/monads/ContinuationMonad.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/monads/ContinuationMonad.scala
@@ -38,12 +38,13 @@ trait ContinuationMonad {
 
         override lazy val eta =
           doubleExp.transpose(dash) {
-            (x, f) => f(x)
+            (x, f) => doubleExp.evaluate(f, x)
           }
 
-        override lazy val mu =
+        override lazy val mu = {
+          implicit val dashDotDotDotDot = dash > dot > dot > dot > dot
           (dash > dot > dot).transpose(
-            dash > dot > dot > dot > dot
+            dashDotDotDotDot
           ) {
             (ffff, f) => ffff(
               (dash > dot > dot > dot).transpose(
@@ -55,6 +56,7 @@ trait ContinuationMonad {
               )
             )
           }
+        }
 
         override def tensorialStrength[
           Y <: ~
@@ -70,6 +72,7 @@ trait ContinuationMonad {
             xys
           ) =>
             implicit val dashDaa = dash x daa
+            implicit val _ = daa > dot > dot
             yss(
               (dot > daa(dashDaa) {
                   y => x ⊕⊕ y
@@ -89,7 +92,7 @@ trait ContinuationMonad {
       dot > (dot > arrow)
 
     lazy val home: Algebra[S] = {
-      val ddd: EXPONENTIAL[S → S, S] = dot > dot > dot
+      implicit val ddd: EXPONENTIAL[S → S, S] = dot > dot > dot
       val structure: (S → S → S) > S =
         ddd(dot) { f =>
           f(

--- a/src/main/scala/com/fdilke/bewl/topos/monads/ContinuationMonad.scala
+++ b/src/main/scala/com/fdilke/bewl/topos/monads/ContinuationMonad.scala
@@ -38,11 +38,14 @@ trait ContinuationMonad {
 
         override lazy val eta =
           doubleExp.transpose(dash) {
-            (x, f) => doubleExp.evaluate(f, x)
+            (x, f) =>
+              implicit val _ = dash > dot
+              f(x)
           }
 
         override lazy val mu = {
-          implicit val dashDotDotDotDot = dash > dot > dot > dot > dot
+          implicit val dashDotDot = dash > dot > dot
+          implicit val dashDotDotDotDot = dashDotDot > dot > dot
           (dash > dot > dot).transpose(
             dashDotDotDotDot
           ) {
@@ -50,7 +53,8 @@ trait ContinuationMonad {
               (dash > dot > dot > dot).transpose(
                 dash > dot
               ) {
-                (x, f) => f(x)
+                (x, f) =>
+                  f(x)
               }(
                 f
               )

--- a/src/test/scala/com/fdilke/bewl/topos/GenericToposTests.scala
+++ b/src/test/scala/com/fdilke/bewl/topos/GenericToposTests.scala
@@ -207,13 +207,15 @@ abstract class GenericToposTests[~](
       evaluation.arrow.sanityTest()
       evaluation.arrow.target shouldBe baz
 
-      val foo2bar2baz: FOO > (BAR → BAZ) = (bar > baz) transpose foobar2baz
+      val foo2bar2baz: FOO > (BAR → BAZ) = 
+        (bar > baz) transpose foobar2baz
       foo2bar2baz.sanityTest()
       foo2bar2baz should have(
         'source(foo),
         'target(bar > baz)
       )
 
+      implicit val _ = bar > baz
       (foo x bar)(baz) {
         case f ⊕ b =>
           foo2bar2baz(f)(b)


### PR DESCRIPTION
Use an evaluate() method on ExponentialDot instead of having elements of an exponential dot behave
functionally.
We can get the same effect using implicits.
This clears the way for a version of the action topos which doesn't have to wrap its elements,
simplifying the code considerably.