### PR TITLE
Fetch maven dependencies securely

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.13.1"
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
-resolvers += "Maven central" at "http://repo1.maven.org/maven2/"
+resolvers += "Maven central" at "https://repo1.maven.org/maven2/"
 //resolvers += Resolver.sonatypeRepo("releases")
 resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
https://central.sonatype.org/articles/2019/Apr/30/http-access-to-repo1mavenorg-and-repomavenapacheorg-is-being-deprecated/